### PR TITLE
Optimize site for phones

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import ImageHelixScroller from "./ImageHelixScroller/ImageHelixScroller";
 import ZeroGBox from "./ZeroGravityPhysics/ZeroGBox";
 import MainStage from "./HoverCubesSection/MainStage";
 import Logo3D from "./components/Logo3D";
+import SectionNav from "./components/SectionNav";
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -19,21 +20,40 @@ function App() {
   return (
     <>
       <Logo3D />
-      <ZeroGBox />
-      <PixelPerfectionist />
-      <GradientScroll />
-      <EasterCube />
-      <InteractiveLove />
-      <ImageHelixScroller />
-      <AdventureMain />
-      <MainStage />
+      <SectionNav />
+      <div className="navSection">
+        <ZeroGBox />
+      </div>
+      <div className="navSection">
+        <PixelPerfectionist />
+      </div>
+      <div className="navSection">
+        <GradientScroll />
+      </div>
+      <div className="navSection">
+        <EasterCube />
+      </div>
+      <div className="navSection">
+        <InteractiveLove />
+      </div>
+      <div className="navSection">
+        <ImageHelixScroller />
+      </div>
+      <div className="navSection">
+        <AdventureMain />
+      </div>
+      <div className="navSection">
+        <MainStage />
+      </div>
       <div
         className="pannelContainer"
         style={{
           height: "40vh",
         }}
       ></div>
-      <ContactForm />
+      <div className="navSection">
+        <ContactForm />
+      </div>
     </>
   );
 }

--- a/src/ImageHelixScroller/ImageHelixScroller.js
+++ b/src/ImageHelixScroller/ImageHelixScroller.js
@@ -59,6 +59,10 @@ const ImageHelixScroller = () => {
   const radius = 7;
   const yOffset = 3;
 
+  // ponytail: read once at mount; no resize handling — a rotated phone
+  // just keeps the slightly wider framing until reload
+  const isPhone = window.matchMedia("(max-width: 820px)").matches;
+
   const animationDataRef = useRef({
     rotation: {
       y: 0,
@@ -133,7 +137,7 @@ const ImageHelixScroller = () => {
         <div className="helixCanvasContainer" ref={canvasDivRef}>
           <LazyMount>
             <Canvas
-              camera={{ position: [12.0, 0, 0] }}
+              camera={{ position: [isPhone ? 15 : 12.0, 0, 0] }}
               style={{
                 width: "100vw",
                 height: "100vh",

--- a/src/components/SectionNav.js
+++ b/src/components/SectionNav.js
@@ -1,0 +1,24 @@
+import React from "react";
+
+// Mobile-only floating button that jumps to the next top-level section.
+// Some sections capture touch (OrbitControls drag) or need many screens
+// of scrolling, so on phones this is the reliable way through the page.
+// Loops back to the top after the last section.
+const SectionNav = () => {
+  const next = () => {
+    const sections = Array.from(document.querySelectorAll(".navSection"));
+    const target = sections.find((s) => s.offsetTop > window.scrollY + 10);
+    window.scrollTo({
+      top: target ? target.offsetTop : 0,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <div className="sectionNav" onClick={next}>
+      &#8595;
+    </div>
+  );
+};
+
+export default SectionNav;

--- a/src/index.css
+++ b/src/index.css
@@ -342,3 +342,97 @@ code {
   justify-content: center;
   align-items: center;
 }
+
+/* section-jump button (phone only) */
+
+.sectionNav {
+  display: none;
+}
+
+/* phone */
+
+@media (max-width: 820px) {
+  * {
+    font-size: 7vw;
+    line-height: 1.2;
+  }
+
+  .center {
+    top: 34%;
+  }
+
+  .bottomText {
+    font-size: 5vw;
+  }
+
+  .downloadBtn {
+    font-size: 6.5vw;
+    border-radius: 12px;
+    padding: 2% 5% 1.5%;
+  }
+
+  .scrollHint {
+    font-size: 13px;
+  }
+
+  .scrollHint .scrollHintArrow {
+    font-size: 17px;
+  }
+
+  .logo3d > div:first-child {
+    width: 44px !important;
+    height: 44px !important;
+  }
+
+  .logoLabel {
+    font-size: 10px;
+  }
+
+  .reasonText {
+    font-size: 7.5vw;
+    top: 12%;
+  }
+
+  .bottomBig {
+    font-size: 42vw;
+  }
+
+  #cross {
+    width: 64px;
+    height: 64px;
+    top: 2vh;
+    right: 6vw;
+  }
+
+  .imageVertical {
+    width: 60%;
+    height: auto;
+  }
+
+  .imageHorizontal {
+    width: 75%;
+    height: auto;
+  }
+
+  .grandchild {
+    margin-top: 50%;
+  }
+
+  .sectionNav {
+    display: flex;
+    position: fixed;
+    bottom: 24px;
+    right: 20px;
+    width: 54px;
+    height: 54px;
+    border-radius: 50%;
+    background: linear-gradient(220deg, #c060ff 1.87%, #3a5fff 100%);
+    align-items: center;
+    justify-content: center;
+    font-size: 26px;
+    line-height: 1;
+    z-index: 40;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.6);
+    cursor: pointer;
+  }
+}


### PR DESCRIPTION
## Summary
- **SectionNav**: floating gradient ↓ button (phone-only) that smooth-scrolls to the next top-level section, looping back to the top after the last one. This is the escape hatch for the "click & drag" OrbitControls panel — which captures single-finger touch and otherwise traps mobile users — and a fast-forward for the long scroll-jacked stretches (helix ≈ 8 screens)
- Phone CSS (`@media (max-width: 820px)`): 7vw base text with 1.2 line-height (desktop's 5vw line-height overlaps when wrapping on narrow screens), bigger footer/resume button, 44px corner logo, resized cube-overlay close button and reason text
- Helix camera pulls back to x=15 on phones so the illustration cards fit the narrow viewport
- Touch notes: physics tap works via r3f pointer events; hover-cube videos already muted+playsInline via drei, so iOS plays them

## Test plan
- Open the preview URL on a phone (or DevTools mobile emulation)
- Tap ↓ repeatedly: should visit every section and loop back to the top
- Verify you can get past the "click & drag" cube section using the button
- Check text legibility in footer/contact and the helix cards' framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)